### PR TITLE
Only Deploy App Once per Action

### DIFF
--- a/.github/workflows/nx-affected-deploy.yaml
+++ b/.github/workflows/nx-affected-deploy.yaml
@@ -14,15 +14,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12.x, 14.x]
-
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "14.x"
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0


### PR DESCRIPTION
ci(demo): only run the affected deploy action on one version of node

The affected deploy action was running twice for two versions of Node, but there's no need for that

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The affected deploy action was being run for node 12.x and 14.x
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #9 

## What is the new behavior?
It now only runs on 14.x

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
