### PR TITLE
Fix Broken README Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
- <img width="20%" height="20%" src="./logo.svg">
+ <img width="20%" height="20%" src="https://raw.githubusercontent.com/ngneat/dag/main/logo.svg">
 </p>
 
 <br />
@@ -16,7 +16,7 @@
 @ngneat/dag is designed to assist in creating and managing a [directed acycylic graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph) model in an Angular application. You can think of a DAG as a workflow where a user adds steps and based on given criteria continues on to the next step or steps. With this library, you can add or remove steps to the DAG and the model will be properly updated. With this part of the workflow being managed by the service, you can focus on what the workflow does rather than how to let the user build it.
 
 <p align="center">
- <img width="100%" height="100%" src="./demo.gif">
+ <img width="100%" height="100%" src="https://raw.githubusercontent.com/ngneat/dag/main/demo.gif">
 </p>
 
 [Live Demo](https://ngneat-dag-demo.netlify.app)


### PR DESCRIPTION
docs: ✏️ fix broken README images

Provided full absolute URLs to the images in github instead of relative
URLs so the images aren't broken

Closes: #22

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
README Images are broken

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #22 

## What is the new behavior?
README images are absolute paths and should show up now.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
